### PR TITLE
Avoid Memory Leak

### DIFF
--- a/app/src/main/java/org/clintonhealthaccess/lmis/app/persistence/DbUtil.java
+++ b/app/src/main/java/org/clintonhealthaccess/lmis/app/persistence/DbUtil.java
@@ -115,7 +115,13 @@ public class DbUtil {
     }
 
     public static <T> Dao<T, String> initialiseDao(SQLiteOpenHelper openHelper, Class<T> domainClass) throws SQLException {
-        ConnectionSource connectionSource = new AndroidConnectionSource(openHelper);
+        ConnectionSource connectionSource;
+        if(openHelper instanceof  LmisSqliteOpenHelper){
+            LmisSqliteOpenHelper helper = (LmisSqliteOpenHelper) openHelper;
+            connectionSource = helper.getConnectionSource();
+        }else{
+            connectionSource = new AndroidConnectionSource(openHelper);
+        }
         return createDao(connectionSource, domainClass);
     }
 }


### PR DESCRIPTION
1. Change DbUtils to share a connection between DAO. Then the DAO can be cached and reused.